### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -26,6 +26,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   sonarQube:
     name: SonarQube
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: "Build & Test"
+permissions:
+  contents: read
 on:
   - pull_request
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/marcolivierarsenault/coffeeanddata/security/code-scanning/5](https://github.com/marcolivierarsenault/coffeeanddata/security/code-scanning/5)

To resolve this, we should add an explicit `permissions:` block. This can be placed either at the root (workflow) level (to apply to all jobs), or at the individual job level if different jobs require different permissions. 

The safest general minimal fix is to add `permissions: contents: read` at the top level, making all jobs least-privilege unless they need more (which does not seem to be the case from the provided code). This does not impact existing behavior since none of the steps shown require write access to the repo via the GitHub API. 

**Specifics:**  
- Add the following block at line 2, immediately after the `name:`:
  ```yaml
  permissions:
    contents: read
  ```
- No imports/methods are needed for YAML workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
