### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,6 +5,8 @@ on:
       - main
 jobs:
   test:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +28,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   sonarQube:
     name: SonarQube
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/marcolivierarsenault/coffeeanddata/security/code-scanning/2](https://github.com/marcolivierarsenault/coffeeanddata/security/code-scanning/2)

To fix the problem, you should explicitly set a `permissions:` block at either the workflow root or individually for each job. The workflow contains two jobs: `test` and `sonarQube`. The `test` job contains a deployment step using `git-publish-subdir-action`, which requires write access to the `contents` of the repository. The SonarQube job does not appear to require write access and can be granted read-only access.

Thus, the best way to fix the problem is:

- At workflow root: Set permissions only if all jobs need the same permissions.
- Per job: Add a `permissions:` block to each job based on its needs (recommended for least privilege).

In this case:
- For the `test` job, add:
  ```yaml
  permissions:
    contents: write
  ```
- For the `sonarQube` job, add:
  ```yaml
  permissions:
    contents: read
  ```

These blocks should go directly under the job name (i.e., immediately after the job's root indentation and before `runs-on`).

_No imports or extra definitions are needed._


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
